### PR TITLE
Bundle exiftool and update version

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -16,7 +16,6 @@
     "ok": "deno fmt -q --check && deno lint -q && deno check -q **/*.ts && deno doc --lint **/*.ts && test -q"
   },
   "imports": {
-    "@david/dax": "jsr:@david/dax@^0.42.0",
     "@cliffy/ansi/colors": "jsr:@cliffy/ansi@1.0.0-rc.7/colors",
     "@cliffy/command": "jsr:@cliffy/command@1.0.0-rc.7",
     "@cliffy/flags": "jsr:@cliffy/flags@1.0.0-rc.7",
@@ -29,6 +28,7 @@
     "@std/text": "jsr:@std/text@^1.0.9",
     "@std/uuid": "jsr:@std/uuid@^1.0.4",
     "@urql/core": "npm:@urql/core@^5.1.0",
-    "@urql/exchange-retry": "npm:@urql/exchange-retry@^1.3.0"
+    "@urql/exchange-retry": "npm:@urql/exchange-retry@^1.3.0",
+    "exiftool-vendored": "npm:exiftool-vendored@^29.0.0"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -8,15 +8,9 @@
     "jsr:@cliffy/keycode@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/prompt@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/table@1.0.0-rc.7": "1.0.0-rc.7",
-    "jsr:@david/dax@*": "0.42.0",
-    "jsr:@david/dax@0.42": "0.42.0",
-    "jsr:@david/path@0.2": "0.2.0",
-    "jsr:@david/which@~0.4.1": "0.4.1",
     "jsr:@std/assert@*": "1.0.10",
-    "jsr:@std/assert@0.221": "0.221.0",
     "jsr:@std/assert@~1.0.6": "1.0.10",
     "jsr:@std/async@^1.0.9": "1.0.9",
-    "jsr:@std/bytes@0.221": "0.221.0",
     "jsr:@std/bytes@^1.0.2": "1.0.4",
     "jsr:@std/collections@^1.0.9": "1.0.9",
     "jsr:@std/crypto@^1.0.3": "1.0.3",
@@ -26,18 +20,17 @@
     "jsr:@std/fs@1": "1.0.8",
     "jsr:@std/fs@^1.0.8": "1.0.8",
     "jsr:@std/internal@^1.0.5": "1.0.5",
-    "jsr:@std/io@0.221": "0.221.0",
     "jsr:@std/io@~0.224.9": "0.224.9",
     "jsr:@std/path@1": "1.0.8",
     "jsr:@std/path@^1.0.8": "1.0.8",
     "jsr:@std/path@~1.0.6": "1.0.8",
-    "jsr:@std/streams@0.221": "0.221.0",
     "jsr:@std/text@^1.0.9": "1.0.9",
     "jsr:@std/text@~1.0.7": "1.0.9",
     "jsr:@std/uuid@^1.0.4": "1.0.4",
     "npm:@types/node@*": "22.5.4",
     "npm:@urql/core@^5.1.0": "5.1.0",
-    "npm:@urql/exchange-retry@^1.3.0": "1.3.0_@urql+core@5.1.0"
+    "npm:@urql/exchange-retry@^1.3.0": "1.3.0_@urql+core@5.1.0",
+    "npm:exiftool-vendored@29": "29.0.0"
   },
   "jsr": {
     "@cliffy/ansi@1.0.0-rc.7": {
@@ -46,7 +39,7 @@
         "jsr:@cliffy/internal",
         "jsr:@std/encoding",
         "jsr:@std/fmt@~1.0.2",
-        "jsr:@std/io@~0.224.9"
+        "jsr:@std/io"
       ]
     },
     "@cliffy/command@1.0.0-rc.7": {
@@ -79,7 +72,7 @@
         "jsr:@cliffy/keycode",
         "jsr:@std/assert@~1.0.6",
         "jsr:@std/fmt@~1.0.2",
-        "jsr:@std/io@~0.224.9",
+        "jsr:@std/io",
         "jsr:@std/path@~1.0.6",
         "jsr:@std/text@~1.0.7"
       ]
@@ -90,31 +83,6 @@
         "jsr:@std/fmt@~1.0.2"
       ]
     },
-    "@david/dax@0.42.0": {
-      "integrity": "0c547c9a20577a6072b90def194c159c9ddab82280285ebfd8268a4ebefbd80b",
-      "dependencies": [
-        "jsr:@david/path",
-        "jsr:@david/which",
-        "jsr:@std/fmt@1",
-        "jsr:@std/fs@1",
-        "jsr:@std/io@0.221",
-        "jsr:@std/path@1",
-        "jsr:@std/streams"
-      ]
-    },
-    "@david/path@0.2.0": {
-      "integrity": "f2d7aa7f02ce5a55e27c09f9f1381794acb09d328f8d3c8a2e3ab3ffc294dccd",
-      "dependencies": [
-        "jsr:@std/fs@1",
-        "jsr:@std/path@1"
-      ]
-    },
-    "@david/which@0.4.1": {
-      "integrity": "896a682b111f92ab866cc70c5b4afab2f5899d2f9bde31ed00203b9c250f225e"
-    },
-    "@std/assert@0.221.0": {
-      "integrity": "a5f1aa6e7909dbea271754fd4ab3f4e687aeff4873b4cef9a320af813adb489a"
-    },
     "@std/assert@1.0.10": {
       "integrity": "59b5cbac5bd55459a19045d95cc7c2ff787b4f8527c0dd195078ff6f9481fbb3",
       "dependencies": [
@@ -123,9 +91,6 @@
     },
     "@std/async@1.0.9": {
       "integrity": "c6472fd0623b3f3daae023cdf7ca5535e1b721dfbf376562c0c12b3fb4867f91"
-    },
-    "@std/bytes@0.221.0": {
-      "integrity": "64a047011cf833890a4a2ab7293ac55a1b4f5a050624ebc6a0159c357de91966"
     },
     "@std/bytes@1.0.4": {
       "integrity": "11a0debe522707c95c7b7ef89b478c13fb1583a7cfb9a85674cd2cc2e3a28abc"
@@ -151,24 +116,11 @@
     "@std/internal@1.0.5": {
       "integrity": "54a546004f769c1ac9e025abd15a76b6671ddc9687e2313b67376125650dc7ba"
     },
-    "@std/io@0.221.0": {
-      "integrity": "faf7f8700d46ab527fa05cc6167f4b97701a06c413024431c6b4d207caa010da",
-      "dependencies": [
-        "jsr:@std/assert@0.221",
-        "jsr:@std/bytes@0.221"
-      ]
-    },
     "@std/io@0.224.9": {
       "integrity": "4414664b6926f665102e73c969cfda06d2c4c59bd5d0c603fd4f1b1c840d6ee3"
     },
     "@std/path@1.0.8": {
       "integrity": "548fa456bb6a04d3c1a1e7477986b6cffbce95102d0bb447c67c4ee70e0364be"
-    },
-    "@std/streams@0.221.0": {
-      "integrity": "47f2f74634b47449277c0ee79fe878da4424b66bd8975c032e3afdca88986e61",
-      "dependencies": [
-        "jsr:@std/io@0.221"
-      ]
     },
     "@std/text@1.0.9": {
       "integrity": "b2db4abc3e6ab93eb0280a0d5e126fd3fca80955bcc297ccaaf555e995eab747"
@@ -176,7 +128,7 @@
     "@std/uuid@1.0.4": {
       "integrity": "f4233149cc8b4753cc3763fd83a7c4101699491f55c7be78dc7b30281946d7a0",
       "dependencies": [
-        "jsr:@std/bytes@^1.0.2",
+        "jsr:@std/bytes",
         "jsr:@std/crypto"
       ]
     }
@@ -184,6 +136,12 @@
   "npm": {
     "@0no-co/graphql.web@1.0.12": {
       "integrity": "sha512-BTDjjsV/zSPy5fqItwm+KWUfh9CSe9tTtR6rCB72ddtkAxdcHbi4Ir4r/L1Et4lyxmL+i7Rb3m9sjLLi9tYrzA=="
+    },
+    "@photostructure/tz-lookup@11.0.0": {
+      "integrity": "sha512-QMV5/dWtY/MdVPXZs/EApqzyhnqDq1keYEqpS+Xj2uidyaqw2Nk/fWcsszdruIXjdqp1VoWNzsgrO6bUHU1mFw=="
+    },
+    "@types/luxon@3.4.2": {
+      "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA=="
     },
     "@types/node@22.5.4": {
       "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
@@ -205,6 +163,33 @@
         "wonka"
       ]
     },
+    "batch-cluster@13.0.0": {
+      "integrity": "sha512-EreW0Vi8TwovhYUHBXXRA5tthuU2ynGsZFlboyMJHCCUXYa2AjgwnE3ubBOJs2xJLcuXFJbi6c/8pH5+FVj8Og=="
+    },
+    "exiftool-vendored.exe@13.0.0": {
+      "integrity": "sha512-4zAMuFGgxZkOoyQIzZMHv1HlvgyJK3AkNqjAgm8A8V0UmOZO7yv3pH49cDV1OduzFJqgs6yQ6eG4OGydhKtxlg=="
+    },
+    "exiftool-vendored.pl@13.0.1": {
+      "integrity": "sha512-+BRRzjselpWudKR0ltAW5SUt9T82D+gzQN8DdOQUgnSVWWp7oLCeTGBRptbQz+436Ihn/mPzmo/xnf0cv/Qw1A=="
+    },
+    "exiftool-vendored@29.0.0": {
+      "integrity": "sha512-BW2Fr7okYP1tN7KIIREy8gOx9WggpPsbKc3BTAS4dLgSup50LjdQttxF9kyDP+27ZayllK+d0rfMYPAixPBtQw==",
+      "dependencies": [
+        "@photostructure/tz-lookup",
+        "@types/luxon",
+        "batch-cluster",
+        "exiftool-vendored.exe",
+        "exiftool-vendored.pl",
+        "he",
+        "luxon"
+      ]
+    },
+    "he@1.2.0": {
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
+    "luxon@3.5.0": {
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ=="
+    },
     "undici-types@6.19.8": {
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
     },
@@ -219,7 +204,6 @@
       "jsr:@cliffy/flags@1.0.0-rc.7",
       "jsr:@cliffy/prompt@1.0.0-rc.7",
       "jsr:@cliffy/table@1.0.0-rc.7",
-      "jsr:@david/dax@0.42",
       "jsr:@std/async@^1.0.9",
       "jsr:@std/collections@^1.0.9",
       "jsr:@std/fs@^1.0.8",
@@ -227,7 +211,8 @@
       "jsr:@std/text@^1.0.9",
       "jsr:@std/uuid@^1.0.4",
       "npm:@urql/core@^5.1.0",
-      "npm:@urql/exchange-retry@^1.3.0"
+      "npm:@urql/exchange-retry@^1.3.0",
+      "npm:exiftool-vendored@29"
     ]
   }
 }

--- a/photos/deno.json
+++ b/photos/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@tugrulates/photos",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "exports": "./mod.ts",
   "tasks": {
     "compile": "deno compile -A -o=../dist/ mod.ts"

--- a/photos/deno.json
+++ b/photos/deno.json
@@ -3,6 +3,6 @@
   "version": "0.1.1",
   "exports": "./mod.ts",
   "tasks": {
-    "compile": "deno compile -RWE --allow-run=exiftool --no-prompt -o=../dist/ mod.ts"
+    "compile": "deno compile -A -o=../dist/ mod.ts"
   }
 }

--- a/photos/fields.ts
+++ b/photos/fields.ts
@@ -1,5 +1,7 @@
+import type { Exif } from "./types.ts";
+
 /** All extracted EXIF fields. */
-export const FIELDS = [
+export const FIELDS: (keyof Exif)[] = [
   "src",
   "width",
   "height",
@@ -13,12 +15,12 @@ export const FIELDS = [
   "country",
   "camera",
   "lens",
-  "editing",
+  "software",
   "license",
 ] as const;
 
 /** EXIF fields that are supposed to be different in variants. */
-export const VARIANT_FIELDS = [
+export const VARIANT_FIELDS: (keyof Exif)[] = [
   "src",
   "width",
   "height",
@@ -26,6 +28,6 @@ export const VARIANT_FIELDS = [
 ] as const;
 
 /** EXIF fields that can be omitted. */
-export const OPTIONAL_FIELDS = [
+export const OPTIONAL_FIELDS: (keyof Exif)[] = [
   "city",
 ] as const;

--- a/photos/main.ts
+++ b/photos/main.ts
@@ -2,7 +2,7 @@ import { colors } from "@cliffy/ansi/colors";
 import { Command } from "@cliffy/command";
 import { omit } from "@std/collections/omit";
 import { expandGlob } from "@std/fs";
-import { join } from "@std/path";
+import { basename, join } from "@std/path";
 import { OPTIONAL_FIELDS, VARIANT_FIELDS } from "./fields.ts";
 import { copyExifToVariants, getPhoto } from "./photo.ts";
 import type { Photo } from "./types.ts";
@@ -40,7 +40,7 @@ function check(data: Photo) {
   }
   for (const size of data.variants) {
     for (const field in omit(size, VARIANT_FIELDS)) {
-      if (field in data) result.push(`${size.src}:${field}`);
+      if (field in data) result.push(`${basename(size.src)}:${field}`);
     }
   }
   if (result.length) return `[${colors.yellow(result.join(", "))}]`;

--- a/photos/mod.ts
+++ b/photos/mod.ts
@@ -1,9 +1,10 @@
 /**
  * Photography editing and publishing workflow.
  *
- * Requires `exiftool` to be present in the system. For macOS, it can be
- * installed using Homebrew with `brew install exiftool`. For other systems,
- * see the [official website](https://exiftool.org/).
+ * The binary for `exiftool` is bundled with this library. However, the
+ * compiled binary `photos` requires `exiftool` to be present in the system.
+ * For macOS, it can be installed using Homebrew with `brew install exiftool`.
+ * For other systems, see the [official website](https://exiftool.org/).
  *
  * @module
  */

--- a/photos/types.ts
+++ b/photos/types.ts
@@ -31,7 +31,7 @@ export interface Exif {
   /** Lens properties that were used to take the photo. */
   lens?: string;
   /** The software used to edit the photo. */
-  editing?: string;
+  software?: string;
   /** The license of the photo. */
   license?: string;
 }


### PR DESCRIPTION
Bundle the exiftool binary with the library and update the version to 0.1.2. Additionally, modify the EXIF interface to use 'software' instead of 'editing'.