### PR TITLE
Fix system exiftool check

### DIFF
--- a/photos/deno.json
+++ b/photos/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@tugrulates/photos",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "exports": "./mod.ts",
   "tasks": {
     "compile": "deno compile -A -o=../dist/ mod.ts"

--- a/photos/photo.ts
+++ b/photos/photo.ts
@@ -9,10 +9,22 @@ interface PhotoTags extends Tags {
   License?: string;
 }
 
+/**
+ * Return an `exiftool` instance.
+ *
+ * @returns The system `exiftool` if it exists, bundled version otherwise.
+ */
 async function getExiftool(): Promise<ExifTool> {
   const command = new Deno.Command("exiftool", { args: ["-v"] });
-  const { code } = await command.output();
-  return new ExifTool({ exiftoolPath: code === 0 ? "exiftool" : undefined });
+  try {
+    await command.output();
+    return new ExifTool({ exiftoolPath: "exiftool" });
+  } catch (e: unknown) {
+    if (e instanceof Deno.errors.NotFound) {
+      return new ExifTool();
+    }
+    throw e;
+  }
 }
 
 function getDate(tags: Tags): string | undefined {


### PR DESCRIPTION
Improve the handling of the `exiftool` command to ensure it returns the correct instance based on its availability on the system. Update the package version to reflect this change.