### PR TITLE
ci: refine title check

### DIFF
--- a/.github/workflows/title.yml
+++ b/.github/workflows/title.yml
@@ -19,17 +19,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           types: |
-            BREAKING
+            build
+            chore
+            ci
+            docs
             feat
             fix
-            docs
-            refactor
             perf
-            test
-            ci
-            chore
+            refactor
             revert
+            style
+            test
           scopes: |
+            \*
             500px
             duolingo
             internal


### PR DESCRIPTION
Allow * scope and drop BREAKING type in favor of exclamation mark.